### PR TITLE
增加getIntent非空判断，解决DSNavigationAccount不调用setIntent时产生的空指针

### DIFF
--- a/library/src/main/java/com/blunderer/materialdesignlibrary/activities/NavigationDrawerActivity.java
+++ b/library/src/main/java/com/blunderer/materialdesignlibrary/activities/NavigationDrawerActivity.java
@@ -386,7 +386,9 @@ public abstract class NavigationDrawerActivity extends AActivity
             headerView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    startActivity(dsNavigationAccount.getIntent());
+                    if (null != dsNavigationAccount.getIntent()) {
+                        startActivity(dsNavigationAccount.getIntent());
+                    }
                 }
             });
 


### PR DESCRIPTION
增加getIntent非空判断，解决DSNavigationAccount不调用setIntent时产生的空指针
